### PR TITLE
[#PR23] Export categories with no parent_id...too

### DIFF
--- a/connector_prestashop_catalog_manager/wizard/export_multiple_products.py
+++ b/connector_prestashop_catalog_manager/wizard/export_multiple_products.py
@@ -87,7 +87,7 @@ class ExportMultipleProducts(models.TransientModel):
                     image.product_id = product
 
     def _check_category(self, product):
-        if not (product.categ_id and product.categ_id.parent_id):
+        if not (product.categ_id):
             return False
         return True
 


### PR DESCRIPTION
Allow root categories to be exported too. Products located in root categories won't get exported. It's not clear what was the reason for that choice. Root categories can get exported just as non root.